### PR TITLE
Fix broken CI badge link in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 :toc: left
 :icons: font
 
-image:https://github.com/henneberger/vertx-pg-logical-replication/actions/workflows/ci.yml/badge.svg["CI and Docs",link="https://github.com/henneberger/vertx-pg-logical-replication/actions/workflows/ci.yml"]
+image:https://github.com/henneberger/vertx-logical-replication/actions/workflows/ci.yml/badge.svg["CI and Docs",link="https://github.com/henneberger/vertx-logical-replication/actions/workflows/ci.yml"]
 
 Reactive, non-blocking change data capture (CDC) and replication streams for Vert.x.
 


### PR DESCRIPTION
## Summary
- update the CI badge image URL in `README.adoc` to point at the current repository
- update the badge hyperlink target to the current repository actions workflow

## Validation
- verified README diff contains only the badge URL/link correction

Closes #1
