### PR TITLE
Build: add Maven Central release GitHub Action

### DIFF
--- a/.github/workflows/release-central.yml
+++ b/.github/workflows/release-central.yml
@@ -1,0 +1,49 @@
+name: Release to Maven Central
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+concurrency:
+  group: release-central-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event_name == 'workflow_dispatch' || github.event.release.target_commitish == 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17 + Maven Central + GPG
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Validate release version is non-SNAPSHOT
+        run: |
+          VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)
+          echo "Project version: ${VERSION}"
+          if [[ "${VERSION}" == *-SNAPSHOT ]]; then
+            echo "Refusing to publish SNAPSHOT version to Maven Central."
+            exit 1
+          fi
+
+      - name: Publish to Maven Central
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        run: mvn -B -ntp -Pcentral-release -DskipTests deploy

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,18 +1,44 @@
 # Publishing
 
+## Maven Central via GitHub Actions
+
+This repository publishes to Maven Central using:
+
+- workflow: `.github/workflows/release-central.yml`
+- Maven profile: `central-release` in the root `pom.xml`
+- Sonatype Central Publisher plugin
+
+## One-time setup required
+
+1. Sonatype Central account and namespace:
+   - Create/sign in at `https://central.sonatype.com/`.
+   - Verify control of the `dev.henneberger` namespace.
+2. Generate a Central publishing token in Sonatype Central.
+3. Create/export a GPG key used for artifact signing.
+4. Add these GitHub repository secrets:
+   - `MAVEN_CENTRAL_USERNAME`
+   - `MAVEN_CENTRAL_TOKEN`
+   - `MAVEN_GPG_PRIVATE_KEY` (ASCII-armored private key)
+   - `MAVEN_GPG_PASSPHRASE`
+
 ## Release checklist
 
-1. Update `pom.xml` version from `-SNAPSHOT` to a release version.
-2. Ensure `README.adoc`, `url`, and `scm` fields are up to date.
-3. Run full verification:
+1. Set project version to a non-`SNAPSHOT` release in `pom.xml`.
+2. Verify project metadata is present and correct (`licenses`, `developers`, `scm`, `url`).
+3. Run full verification locally:
    ```bash
    mvn clean verify
    ```
-4. Publish artifacts to your configured repository manager.
-5. Tag the release in git and push.
+4. Merge release changes to `main`.
+5. Trigger publish either by:
+   - publishing a GitHub Release targeting `main`, or
+   - running `Release to Maven Central` via `workflow_dispatch`.
+
+The workflow fails if `project.version` is still `-SNAPSHOT`.
 
 ## Produced artifacts
 
 - Main jar
 - Sources jar
 - Javadocs jar
+- `.asc` signatures for published artifacts

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,30 @@
 
   <name>Vert.x Replication Parent</name>
   <description>Multi-database replication streams for Vert.x</description>
-  <url>https://github.com/henneberger/vertx-pg-logical-replication</url>
+  <url>https://github.com/henneberger/vertx-logical-replication</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>henneberger</id>
+      <name>Daniel Henneberger</name>
+      <url>https://github.com/henneberger</url>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/henneberger/vertx-logical-replication.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/henneberger/vertx-logical-replication.git</developerConnection>
+    <url>https://github.com/henneberger/vertx-logical-replication</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <modules>
     <module>replication-core</module>
@@ -54,6 +77,9 @@
     <slf4j.version>2.0.17</slf4j.version>
     <asciidoctor.maven.plugin.version>3.2.0</asciidoctor.maven.plugin.version>
     <maven.assembly.plugin.version>3.7.1</maven.assembly.plugin.version>
+    <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
+    <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
+    <central.publishing.maven.plugin.version>0.9.0</central.publishing.maven.plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -67,6 +93,14 @@
   </dependencyManagement>
 
   <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -83,6 +117,18 @@
               <id>attach-sources</id>
               <goals>
                 <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${maven.javadoc.plugin.version}</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
               </goals>
             </execution>
           </executions>
@@ -148,6 +194,40 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>central-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${maven.gpg.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <bestPractices>true</bestPractices>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${central.publishing.maven.plugin.version}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish releases to Maven Central
- add Maven `central-release` profile with signing + Central Publisher plugin
- document required GitHub secrets and release process in `PUBLISHING.md`

## Notes
- workflow refuses to publish `-SNAPSHOT` versions
- requires `MAVEN_GPG_PRIVATE_KEY` and `MAVEN_GPG_PASSPHRASE` secrets before first release
