### PR TITLE
feat(cockroachdb): sinkless true CDC adapter for non-prod

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -48,12 +48,22 @@ Support by connector:
 - MongoDB (`replication-mongodb`): *True CDC / native change streams* via `watch()`.
 - SQL Server (`replication-sqlserver`): *Polling CDC adapter* over SQL Server CDC tables/functions.
 - MariaDB (`replication-mariadb`): *Polling CDC adapter* (JDBC polling model).
-- CockroachDB (`replication-cockroachdb`): *Polling CDC adapter* (JDBC polling model).
+- CockroachDB (`replication-cockroachdb`): *True CDC / changefeed stream* via sinkless changefeed for dev/test/prototype usage (non-production), using Cockroach SQL client streaming.
 - Oracle (`replication-oracle`): *Polling CDC adapter* (JDBC polling model).
 - Db2 (`replication-db2`): *Polling CDC adapter* (JDBC polling model).
 - Cassandra (`replication-cassandra`): *Polling CDC adapter* over source/event rows.
 - ScyllaDB (`replication-scylladb`): *Polling CDC adapter* over source/event rows.
 - Neo4j (`replication-neo4j`): *Polling CDC adapter* over configured event query.
+
+[NOTE]
+====
+CockroachDB connector tradeoffs (current implementation):
+
+- It is true CDC (sinkless changefeed), not polling.
+- It is intended for dev/test/prototype environments, not production.
+- It streams through the Cockroach SQL CLI process (`cockroach sql`), so runtime hosts must have CLI access and permissions to run the command.
+- For production-grade Cockroach CDC, prefer managed sink integrations (for example Kafka/webhook) outside this adapter.
+====
 
 == Requirements
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -9,7 +9,7 @@ This manual uses PostgreSQL as the full walkthrough and lists all supported conn
 * SQL Server CDC polling
 * MySQL binlog CDC
 * MariaDB CDC adapter (currently polling)
-* CockroachDB CDC adapter (currently polling)
+* CockroachDB sinkless changefeed CDC (dev/test/prototype)
 * Oracle CDC adapter (currently polling)
 * Db2 CDC adapter (currently polling)
 * Cassandra CDC adapter (DB-native)
@@ -73,9 +73,9 @@ If you are using Maven, add the dependency for the connector you need:
 
 | CockroachDB
 | `vertx-cockroachdb-cdc-replication`
-| `POLLING`
-| Polling CDC
-| Supported. Polling adapter today; planned migration to changefeed stream mode.
+| `LOG_STREAM`
+| True log-stream
+| Supported for non-production usage. Uses sinkless changefeed stream semantics.
 
 | Oracle
 | `vertx-oracle-cdc-replication`
@@ -193,7 +193,7 @@ Non-PostgreSQL connectors have database-specific setup differences. Minimum chec
 
 * SQL Server: enable SQL Server Agent, `sp_cdc_enable_db`, and table-level CDC/capture instance.
 * MySQL and MariaDB: enable binlog, use ROW format, and verify connector/auth compatibility.
-* CockroachDB: verify CDC/changefeed permissions and sink/source compatibility used by the adapter.
+* CockroachDB: verify CDC/changefeed permissions and Cockroach SQL client availability used by the adapter.
 * Oracle: verify required CDC/log mining prerequisites and connector principal privileges.
 * Db2: verify CDC/change data capture setup and polling/query privileges.
 * Cassandra and ScyllaDB: verify CDC is enabled at table/keyspace level and retention windows match consumer lag.

--- a/replication-cockroachdb/src/main/java/dev/henneberger/vertx/cockroachdb/replication/CockroachDbLogicalReplicationStream.java
+++ b/replication-cockroachdb/src/main/java/dev/henneberger/vertx/cockroachdb/replication/CockroachDbLogicalReplicationStream.java
@@ -1,32 +1,43 @@
 package dev.henneberger.vertx.cockroachdb.replication;
 
-import dev.henneberger.vertx.replication.core.AbstractJdbcPollingReplicationStream;
+import dev.henneberger.vertx.replication.core.AbstractWorkerReplicationStream;
+import dev.henneberger.vertx.replication.core.AdapterMode;
 import dev.henneberger.vertx.replication.core.ChangeConsumer;
 import dev.henneberger.vertx.replication.core.ChangeFilter;
-import dev.henneberger.vertx.replication.core.ReplicationSubscription;
+import dev.henneberger.vertx.replication.core.LsnStore;
+import dev.henneberger.vertx.replication.core.PreflightIssue;
+import dev.henneberger.vertx.replication.core.PreflightReport;
+import dev.henneberger.vertx.replication.core.ReplicationStateChange;
 import dev.henneberger.vertx.replication.core.RetryPolicy;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.sql.Array;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.Locale;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CockroachDbLogicalReplicationStream extends AbstractJdbcPollingReplicationStream<CockroachDbChangeEvent> {
+public class CockroachDbLogicalReplicationStream extends AbstractWorkerReplicationStream<CockroachDbChangeEvent> {
   private static final Logger LOG = LoggerFactory.getLogger(CockroachDbLogicalReplicationStream.class);
 
   private final CockroachDbReplicationOptions options;
+
+  private volatile Connection connection;
+  private volatile Process changefeedProcess;
+  private volatile BufferedReader changefeedReader;
 
   public CockroachDbLogicalReplicationStream(Vertx vertx, CockroachDbReplicationOptions options) {
     super(vertx);
@@ -37,60 +48,29 @@ public class CockroachDbLogicalReplicationStream extends AbstractJdbcPollingRepl
   public CockroachDbChangeSubscription subscribe(CockroachDbChangeFilter filter,
                                                  CockroachDbChangeConsumer eventConsumer,
                                                  Handler<Throwable> errorHandler) {
-    ReplicationSubscription subscription = registerSubscription(filter, eventConsumer, errorHandler, true);
-    return subscription::cancel;
+    return () -> registerSubscription(filter, eventConsumer, errorHandler, true).cancel();
   }
 
   @Override
-  public ReplicationSubscription subscribe(ChangeFilter<CockroachDbChangeEvent> filter,
-                                           ChangeConsumer<CockroachDbChangeEvent> eventConsumer,
-                                           Handler<Throwable> errorHandler) {
-    return registerSubscription(filter, eventConsumer, errorHandler, true);
+  public CockroachDbChangeSubscription subscribe(ChangeFilter<CockroachDbChangeEvent> filter,
+                                                 ChangeConsumer<CockroachDbChangeEvent> eventConsumer,
+                                                 Handler<Throwable> errorHandler) {
+    return () -> registerSubscription(filter, eventConsumer, errorHandler, true).cancel();
+  }
+
+  @Override
+  public AdapterMode adapterMode() {
+    return AdapterMode.LOG_STREAM;
   }
 
   @Override
   protected String streamName() {
-    return "cockroachdb-cdc";
-  }
-
-  @Override
-  protected void logStreamFailure(Throwable error) {
-    LOG.error("CockroachDb CDC stream failed for {}", options.getSourceTable(), error);
-  }
-
-  @Override
-  protected String sourceTable() {
-    return options.getSourceTable();
-  }
-
-  @Override
-  protected String positionColumn() {
-    return options.getPositionColumn();
-  }
-
-  @Override
-  protected String rowLimitClause() {
-    return "LIMIT ?";
-  }
-
-  @Override
-  protected int batchSize() {
-    return options.getBatchSize();
+    return "cockroachdb-cdc-" + options.getSourceTable();
   }
 
   @Override
   protected int maxConcurrentDispatch() {
     return options.getMaxConcurrentDispatch();
-  }
-
-  @Override
-  protected long pollIntervalMs() {
-    return options.getPollIntervalMs();
-  }
-
-  @Override
-  protected RetryPolicy retryPolicy() {
-    return options.getRetryPolicy();
   }
 
   @Override
@@ -104,50 +84,288 @@ public class CockroachDbLogicalReplicationStream extends AbstractJdbcPollingRepl
   }
 
   @Override
-  protected Connection openConnection() throws Exception {
+  protected RetryPolicy retryPolicy() {
+    return options.getRetryPolicy();
+  }
+
+  @Override
+  protected LsnStore checkpointStore() {
+    return options.getLsnStore();
+  }
+
+  @Override
+  protected PreflightReport runPreflightChecks() {
+    List<PreflightIssue> issues = new ArrayList<>();
+    try (Connection conn = openConnection()) {
+      try (PreparedStatement ps = conn.prepareStatement("SELECT 1"); ResultSet rs = ps.executeQuery()) {
+        rs.next();
+      }
+      checkSourceTableExists(conn, issues);
+    } catch (Exception e) {
+      issues.add(new PreflightIssue(
+        PreflightIssue.Severity.ERROR,
+        "CONNECTION_FAILED",
+        "Could not connect to CockroachDB: " + e.getMessage(),
+        "Verify host, port, database, user, password, and SSL settings."
+      ));
+    }
+    return new PreflightReport(issues);
+  }
+
+  @Override
+  protected void runSession(long attempt) throws Exception {
+    String checkpointKey = checkpointKey();
+    String storedCursor = loadCheckpoint(checkpointKey);
+    String effectiveCursor = (storedCursor == null || storedCursor.isBlank()) ? options.getInitialCursor() : storedCursor;
+    runCliSession(attempt, checkpointKey, effectiveCursor);
+  }
+
+  @Override
+  protected void logStreamFailure(Throwable error) {
+    LOG.error("CockroachDB CDC stream failed for {}", options.getSourceTable(), error);
+  }
+
+  @Override
+  protected void onCloseResources() {
+    BufferedReader reader = changefeedReader;
+    changefeedReader = null;
+    if (reader != null) {
+      try {
+        reader.close();
+      } catch (Exception ignore) {
+      }
+    }
+
+    Process process = changefeedProcess;
+    changefeedProcess = null;
+    if (process != null) {
+      try {
+        process.destroy();
+      } catch (Exception ignore) {
+      }
+    }
+
+    Connection conn = connection;
+    connection = null;
+    if (conn != null) {
+      try {
+        conn.close();
+      } catch (Exception ignore) {
+      }
+    }
+  }
+
+  private Connection openConnection() throws Exception {
     String url = "jdbc:postgresql://" + options.getHost() + ":" + options.getPort() + "/" + options.getDatabase();
     return DriverManager.getConnection(url, options.getUser(), resolvePassword());
   }
 
-  @Override
-  protected CockroachDbChangeEvent mapRow(ResultSet rs) throws Exception {
-    Map<String, Object> row = extractRow(rs);
-    String operationRaw = asString(row.get(options.getOperationColumn()));
-    CockroachDbChangeEvent.Operation operation = mapOperation(operationRaw);
-    Map<String, Object> before = parseMap(row.get(options.getBeforeColumn()));
-    Map<String, Object> after = parseMap(row.get(options.getAfterColumn()));
-    if (after.isEmpty()) {
-      after = new LinkedHashMap<>(row);
-      after.remove(options.getOperationColumn());
-      after.remove(options.getBeforeColumn());
-      after.remove(options.getAfterColumn());
+  private void runCliSession(long attempt, String checkpointKey, String cursor) throws Exception {
+    String query = buildChangefeedQuery(cursor);
+    List<String> command = buildCliCommand(query);
+    Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+    BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+    this.changefeedProcess = process;
+    this.changefeedReader = reader;
+    boolean started = false;
+
+    String line;
+    while (shouldRun() && (line = reader.readLine()) != null) {
+      String trimmed = line.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      if ("table,key,value".equalsIgnoreCase(trimmed)) {
+        if (!started) {
+          transition(dev.henneberger.vertx.replication.core.ReplicationStreamState.RUNNING, null, attempt);
+          completeStart();
+          started = true;
+        }
+        continue;
+      }
+      if (trimmed.startsWith("ERROR:")) {
+        throw new IllegalStateException("Cockroach changefeed command failed: " + trimmed);
+      }
+
+      Map<String, Object> row = parseCsvRow(trimmed);
+      if (row == null) {
+        continue;
+      }
+      if (!started) {
+        transition(dev.henneberger.vertx.replication.core.ReplicationStreamState.RUNNING, null, attempt);
+        completeStart();
+        started = true;
+      }
+
+      CockroachDbChangeEvent event = mapChangefeedRow(row);
+      if (event == null) {
+        continue;
+      }
+      dispatchAndAwait(event);
+      emitEventMetric(event);
+
+      String token = event.getPosition();
+      if (token != null && !token.isBlank()) {
+        saveCheckpoint(checkpointKey, token);
+        emitLsnCommitted(checkpointKey, token);
+      }
     }
-    Instant commitTs = toInstant(row.get(options.getCommitTimestampColumn()));
-    String position = asString(row.get(options.getPositionColumn()));
+
+    if (!started && shouldRun()) {
+      throw new IllegalStateException("Cockroach changefeed command ended before stream startup");
+    }
+
+    if (shouldRun()) {
+      int exit = process.waitFor();
+      if (exit != 0) {
+        throw new IllegalStateException("Cockroach changefeed command exited with code " + exit);
+      }
+    }
+  }
+
+  private List<String> buildCliCommand(String query) {
+    List<String> configured = options.getCliCommand();
+    List<String> command = new ArrayList<>();
+    if (configured.isEmpty()) {
+      command.add("cockroach");
+      command.add("sql");
+      command.add("--insecure");
+      command.add("--host=" + options.getHost() + ":" + options.getPort());
+      command.add("--database=" + options.getDatabase());
+      command.add("--format=csv");
+      command.add("-e");
+      command.add(query);
+      return command;
+    }
+
+    boolean replaced = false;
+    for (String token : configured) {
+      if ("{query}".equals(token)) {
+        command.add(query);
+        replaced = true;
+      } else {
+        command.add(token);
+      }
+    }
+    if (!replaced) {
+      command.add(query);
+    }
+    return command;
+  }
+
+  private String buildChangefeedQuery(String cursor) {
+    Map<String, Object> opts = new LinkedHashMap<>(options.getChangefeedOptions());
+    opts.putIfAbsent("envelope", "wrapped");
+    opts.putIfAbsent("diff", true);
+    opts.putIfAbsent("updated", true);
+    opts.putIfAbsent("resolved", "1s");
+    if (cursor != null && !cursor.isBlank()) {
+      opts.putIfAbsent("cursor", cursor);
+    }
+
+    StringBuilder query = new StringBuilder("EXPERIMENTAL CHANGEFEED FOR TABLE ")
+      .append(options.getSourceTable());
+
+    if (!opts.isEmpty()) {
+      query.append(" WITH ");
+      boolean first = true;
+      for (Map.Entry<String, Object> entry : opts.entrySet()) {
+        if (!first) {
+          query.append(", ");
+        }
+        first = false;
+        query.append(entry.getKey());
+        Object value = entry.getValue();
+        if (value instanceof Boolean) {
+          if (!((Boolean) value)) {
+            query.append(" = false");
+          }
+          continue;
+        }
+        if (value instanceof Number) {
+          query.append(" = ").append(value);
+          continue;
+        }
+        if (value != null) {
+          query.append(" = '").append(escapeSql(value.toString())).append("'");
+        }
+      }
+    }
+
+    return query.toString();
+  }
+
+  private CockroachDbChangeEvent mapChangefeedRow(Map<String, Object> row) {
+    String source = asString(getAny(row, "table", "topic"));
+    if (source == null || source.isBlank()) {
+      source = options.getSourceTable();
+    }
+
+    Object valueRaw = getAny(row, "value", "v");
+    if (valueRaw == null) {
+      return null;
+    }
+
+    JsonObject envelope = parseEnvelope(valueRaw);
+    if (envelope == null) {
+      return null;
+    }
+    if (envelope.containsKey("resolved") && !envelope.containsKey("before") && !envelope.containsKey("after")) {
+      return null;
+    }
+
+    Map<String, Object> before = asMap(envelope.getValue("before"));
+    Map<String, Object> after = asMap(envelope.getValue("after"));
+    String updated = asString(getAny(row, "updated", "mvcc_timestamp"));
+    if (updated == null || updated.isBlank()) {
+      updated = envelope.getString("updated");
+    }
+
+    CockroachDbChangeEvent.Operation operation = operationFor(before, after);
     Map<String, Object> metadata = new LinkedHashMap<>();
     metadata.put("adapter", "cockroachdb");
-    metadata.put("rawOperation", operationRaw);
-    return new CockroachDbChangeEvent(options.getSourceTable(), operation, before, after, position, commitTs, metadata);
+    metadata.put("rawKey", toText(getAny(row, "key", "k")));
+    metadata.put("rawValue", toText(valueRaw));
+
+    return new CockroachDbChangeEvent(
+      source,
+      operation,
+      before,
+      after,
+      updated,
+      parseInstant(updated),
+      metadata
+    );
   }
 
-  @Override
-  protected String eventPosition(CockroachDbChangeEvent event) {
-    return event.getPosition();
+  private void checkSourceTableExists(Connection conn, List<PreflightIssue> issues) throws Exception {
+    String table = options.getSourceTable();
+    String schema = "public";
+    if (table.contains(".")) {
+      int idx = table.indexOf('.');
+      schema = table.substring(0, idx);
+      table = table.substring(idx + 1);
+    }
+
+    try (PreparedStatement ps = conn.prepareStatement(
+      "SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")) {
+      ps.setString(1, schema);
+      ps.setString(2, table);
+      try (ResultSet rs = ps.executeQuery()) {
+        if (!rs.next()) {
+          issues.add(new PreflightIssue(
+            PreflightIssue.Severity.ERROR,
+            "SOURCE_TABLE_MISSING",
+            "Source table '" + options.getSourceTable() + "' was not found",
+            "Create the table and verify sourceTable configuration."
+          ));
+        }
+      }
+    }
   }
 
-  @Override
-  protected String checkpointKey() {
+  private String checkpointKey() {
     return "cockroachdb:" + options.getDatabase() + ":" + options.getSourceTable();
-  }
-
-  @Override
-  protected Optional<String> loadCheckpoint() throws Exception {
-    return options.getLsnStore().load(checkpointKey());
-  }
-
-  @Override
-  protected void saveCheckpoint(String token) throws Exception {
-    options.getLsnStore().save(checkpointKey(), token);
   }
 
   private String resolvePassword() {
@@ -161,59 +379,174 @@ public class CockroachDbLogicalReplicationStream extends AbstractJdbcPollingRepl
     return password == null ? "" : password;
   }
 
-  private static CockroachDbChangeEvent.Operation mapOperation(String op) {
-    String n = op == null ? "" : op.trim().toUpperCase(Locale.ROOT);
-    if (n.startsWith("INS")) {
+  private static String escapeSql(String value) {
+    return value.replace("'", "''");
+  }
+
+  private static Object getAny(Map<String, Object> row, String... keys) {
+    for (String key : keys) {
+      if (row.containsKey(key)) {
+        return row.get(key);
+      }
+    }
+    return null;
+  }
+
+  private static String asString(Object value) {
+    if (value == null) {
+      return null;
+    }
+    return String.valueOf(value);
+  }
+
+  private static JsonObject parseEnvelope(Object raw) {
+    try {
+      String text = toText(raw);
+      if (text == null || text.isBlank() || "null".equalsIgnoreCase(text.trim())) {
+        return null;
+      }
+      return new JsonObject(text);
+    } catch (Exception ignore) {
+      return null;
+    }
+  }
+
+  private static Map<String, Object> asMap(Object raw) {
+    if (raw == null) {
+      return Map.of();
+    }
+    if (raw instanceof Map) {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> map = (Map<String, Object>) raw;
+      return new LinkedHashMap<>(map);
+    }
+    if (raw instanceof JsonObject) {
+      return ((JsonObject) raw).getMap();
+    }
+    try {
+      return new JsonObject(String.valueOf(raw)).getMap();
+    } catch (Exception ignore) {
+      return Map.of();
+    }
+  }
+
+  private static CockroachDbChangeEvent.Operation operationFor(Map<String, Object> before, Map<String, Object> after) {
+    boolean hasBefore = before != null && !before.isEmpty();
+    boolean hasAfter = after != null && !after.isEmpty();
+    if (hasAfter && !hasBefore) {
       return CockroachDbChangeEvent.Operation.INSERT;
     }
-    if (n.startsWith("DEL")) {
+    if (!hasAfter && hasBefore) {
       return CockroachDbChangeEvent.Operation.DELETE;
     }
     return CockroachDbChangeEvent.Operation.UPDATE;
   }
 
-  private static Map<String, Object> parseMap(Object raw) {
+  private static Instant parseInstant(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    String trimmed = value.trim();
+    int dot = trimmed.indexOf('.');
+    String numeric = dot >= 0 ? trimmed.substring(0, dot) : trimmed;
+    if (!numeric.isBlank() && numeric.chars().allMatch(Character::isDigit)) {
+      try {
+        long epochNanos = Long.parseLong(numeric);
+        long epochSeconds = epochNanos / 1_000_000_000L;
+        long nanosAdjustment = epochNanos % 1_000_000_000L;
+        return Instant.ofEpochSecond(epochSeconds, nanosAdjustment);
+      } catch (Exception ignore) {
+      }
+    }
+    try {
+      return Instant.parse(value);
+    } catch (Exception ignore) {
+      try {
+        return Timestamp.valueOf(value.replace('T', ' ').replace("Z", "")).toInstant();
+      } catch (Exception ignoreAgain) {
+        return null;
+      }
+    }
+  }
+
+  private static String toText(Object raw) {
     if (raw == null) {
-      return Collections.emptyMap();
-    }
-    if (raw instanceof Map) {
-      return new LinkedHashMap<>((Map<String, Object>) raw);
-    }
-    try {
-      JsonObject json = raw instanceof JsonObject ? (JsonObject) raw : new JsonObject(String.valueOf(raw));
-      return json.getMap();
-    } catch (Exception ignore) {
-      return Collections.emptyMap();
-    }
-  }
-
-  private static Instant toInstant(Object value) {
-    if (value == null) {
       return null;
     }
-    if (value instanceof Instant) {
-      return (Instant) value;
+    if (raw instanceof byte[]) {
+      return new String((byte[]) raw, StandardCharsets.UTF_8);
     }
-    if (value instanceof Timestamp) {
-      return ((Timestamp) value).toInstant();
+    if (raw instanceof Array) {
+      try {
+        return toText(((Array) raw).getArray());
+      } catch (Exception ignore) {
+        return String.valueOf(raw);
+      }
     }
-    try {
-      return Instant.parse(String.valueOf(value));
-    } catch (Exception ignore) {
+    String text = String.valueOf(raw);
+    String decoded = decodeHexText(text);
+    return decoded != null ? decoded : text;
+  }
+
+  private static String decodeHexText(String text) {
+    if (text == null || text.length() < 3 || !text.startsWith("\\x")) {
       return null;
     }
-  }
-
-  private static String asString(Object value) {
-    return value == null ? "" : String.valueOf(value);
-  }
-
-  private static Map<String, Object> extractRow(ResultSet rs) throws Exception {
-    ResultSetMetaData md = rs.getMetaData();
-    Map<String, Object> out = new LinkedHashMap<>();
-    for (int i = 1; i <= md.getColumnCount(); i++) {
-      out.put(md.getColumnLabel(i), rs.getObject(i));
+    String hex = text.substring(2);
+    if ((hex.length() & 1) != 0) {
+      return null;
     }
-    return out;
+    byte[] out = new byte[hex.length() / 2];
+    for (int i = 0; i < hex.length(); i += 2) {
+      int hi = Character.digit(hex.charAt(i), 16);
+      int lo = Character.digit(hex.charAt(i + 1), 16);
+      if (hi < 0 || lo < 0) {
+        return null;
+      }
+      out[i / 2] = (byte) ((hi << 4) + lo);
+    }
+    return new String(out, StandardCharsets.UTF_8);
+  }
+
+  private static Map<String, Object> parseCsvRow(String line) {
+    List<String> fields = splitCsv(line);
+    if (fields.size() < 3) {
+      return null;
+    }
+    Map<String, Object> row = new LinkedHashMap<>();
+    row.put("table", csvNull(fields.get(0)));
+    row.put("key", csvNull(fields.get(1)));
+    row.put("value", csvNull(fields.get(2)));
+    return row;
+  }
+
+  private static String csvNull(String value) {
+    return value == null || "NULL".equalsIgnoreCase(value) ? null : value;
+  }
+
+  private static List<String> splitCsv(String line) {
+    List<String> values = new ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    boolean inQuotes = false;
+    for (int i = 0; i < line.length(); i++) {
+      char ch = line.charAt(i);
+      if (ch == '"') {
+        if (inQuotes && i + 1 < line.length() && line.charAt(i + 1) == '"') {
+          current.append('"');
+          i++;
+        } else {
+          inQuotes = !inQuotes;
+        }
+        continue;
+      }
+      if (ch == ',' && !inQuotes) {
+        values.add(current.toString());
+        current.setLength(0);
+        continue;
+      }
+      current.append(ch);
+    }
+    values.add(current.toString());
+    return values;
   }
 }

--- a/replication-cockroachdb/src/main/java/dev/henneberger/vertx/cockroachdb/replication/CockroachDbReplicationOptions.java
+++ b/replication-cockroachdb/src/main/java/dev/henneberger/vertx/cockroachdb/replication/CockroachDbReplicationOptions.java
@@ -8,6 +8,11 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @DataObject
@@ -24,6 +29,9 @@ public class CockroachDbReplicationOptions {
   private String password;
   private String passwordEnv;
   private String sourceTable;
+  private String initialCursor;
+  private Map<String, Object> changefeedOptions;
+  private List<String> cliCommand;
   private String positionColumn;
   private String operationColumn;
   private String beforeColumn;
@@ -48,6 +56,9 @@ public class CockroachDbReplicationOptions {
     this.password = other.password;
     this.passwordEnv = other.passwordEnv;
     this.sourceTable = other.sourceTable;
+    this.initialCursor = other.initialCursor;
+    this.changefeedOptions = new LinkedHashMap<>(other.changefeedOptions);
+    this.cliCommand = new ArrayList<>(other.cliCommand);
     this.positionColumn = other.positionColumn;
     this.operationColumn = other.operationColumn;
     this.beforeColumn = other.beforeColumn;
@@ -76,6 +87,18 @@ public class CockroachDbReplicationOptions {
   public CockroachDbReplicationOptions setPasswordEnv(String passwordEnv) { this.passwordEnv = passwordEnv; return this; }
   public String getSourceTable() { return sourceTable; }
   public CockroachDbReplicationOptions setSourceTable(String sourceTable) { this.sourceTable = sourceTable; return this; }
+  public String getInitialCursor() { return initialCursor; }
+  public CockroachDbReplicationOptions setInitialCursor(String initialCursor) { this.initialCursor = initialCursor; return this; }
+  public Map<String, Object> getChangefeedOptions() { return Collections.unmodifiableMap(changefeedOptions); }
+  public CockroachDbReplicationOptions setChangefeedOptions(Map<String, Object> changefeedOptions) {
+    this.changefeedOptions = changefeedOptions == null ? new LinkedHashMap<>() : new LinkedHashMap<>(changefeedOptions);
+    return this;
+  }
+  public List<String> getCliCommand() { return Collections.unmodifiableList(cliCommand); }
+  public CockroachDbReplicationOptions setCliCommand(List<String> cliCommand) {
+    this.cliCommand = cliCommand == null ? new ArrayList<>() : new ArrayList<>(cliCommand);
+    return this;
+  }
   public String getPositionColumn() { return positionColumn; }
   public CockroachDbReplicationOptions setPositionColumn(String positionColumn) { this.positionColumn = positionColumn; return this; }
   public String getOperationColumn() { return operationColumn; }
@@ -115,10 +138,9 @@ public class CockroachDbReplicationOptions {
     OptionValidation.require("database", database);
     OptionValidation.require("user", user);
     OptionValidation.require("sourceTable", sourceTable);
-    OptionValidation.require("positionColumn", positionColumn);
-    OptionValidation.requireMin("pollIntervalMs", pollIntervalMs, 1);
-    OptionValidation.requireMin("batchSize", batchSize, 1);
     OptionValidation.requireMin("maxConcurrentDispatch", maxConcurrentDispatch, 1);
+    Objects.requireNonNull(changefeedOptions, "changefeedOptions");
+    Objects.requireNonNull(cliCommand, "cliCommand");
     Objects.requireNonNull(retryPolicy, "retryPolicy").validate();
     Objects.requireNonNull(lsnStore, "lsnStore");
   }
@@ -126,6 +148,9 @@ public class CockroachDbReplicationOptions {
   private void init() {
     host = DEFAULT_HOST;
     port = DEFAULT_PORT;
+    initialCursor = null;
+    changefeedOptions = new LinkedHashMap<>();
+    cliCommand = new ArrayList<>();
     positionColumn = "position";
     operationColumn = "operation";
     beforeColumn = "before_json";

--- a/replication-cockroachdb/src/main/java/dev/henneberger/vertx/cockroachdb/replication/CockroachDbReplicationOptionsConverter.java
+++ b/replication-cockroachdb/src/main/java/dev/henneberger/vertx/cockroachdb/replication/CockroachDbReplicationOptionsConverter.java
@@ -1,6 +1,7 @@
 package dev.henneberger.vertx.cockroachdb.replication;
 
 import dev.henneberger.vertx.replication.core.RetryPolicy;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.time.Duration;
 
@@ -16,6 +17,11 @@ final class CockroachDbReplicationOptionsConverter {
     if (json.containsKey("password")) options.setPassword(json.getString("password"));
     if (json.containsKey("passwordEnv")) options.setPasswordEnv(json.getString("passwordEnv"));
     if (json.containsKey("sourceTable")) options.setSourceTable(json.getString("sourceTable"));
+    if (json.containsKey("initialCursor")) options.setInitialCursor(json.getString("initialCursor"));
+    JsonObject changefeedOptions = json.getJsonObject("changefeedOptions");
+    if (changefeedOptions != null) options.setChangefeedOptions(changefeedOptions.getMap());
+    JsonArray cliCommand = json.getJsonArray("cliCommand");
+    if (cliCommand != null) options.setCliCommand(cliCommand.getList());
     if (json.containsKey("positionColumn")) options.setPositionColumn(json.getString("positionColumn"));
     if (json.containsKey("operationColumn")) options.setOperationColumn(json.getString("operationColumn"));
     if (json.containsKey("beforeColumn")) options.setBeforeColumn(json.getString("beforeColumn"));
@@ -47,6 +53,9 @@ final class CockroachDbReplicationOptionsConverter {
     json.put("password", options.getPassword());
     json.put("passwordEnv", options.getPasswordEnv());
     json.put("sourceTable", options.getSourceTable());
+    json.put("initialCursor", options.getInitialCursor());
+    json.put("changefeedOptions", new JsonObject(options.getChangefeedOptions()));
+    json.put("cliCommand", new JsonArray(options.getCliCommand()));
     json.put("positionColumn", options.getPositionColumn());
     json.put("operationColumn", options.getOperationColumn());
     json.put("beforeColumn", options.getBeforeColumn());

--- a/replication-cockroachdb/src/test/java/dev/henneberger/vertx/cockroachdb/replication/CockroachDbReplicationOptionsTest.java
+++ b/replication-cockroachdb/src/test/java/dev/henneberger/vertx/cockroachdb/replication/CockroachDbReplicationOptionsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.core.json.JsonObject;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class CockroachDbReplicationOptionsTest {
@@ -18,6 +19,9 @@ class CockroachDbReplicationOptionsTest {
       .put("user", "root")
       .put("passwordEnv", "COCKROACH_PASSWORD")
       .put("sourceTable", "cdc_orders")
+      .put("initialCursor", "2026-02-16T00:00:00Z")
+      .put("changefeedOptions", new JsonObject().put("resolved", "5s"))
+      .put("cliCommand", List.of("cockroach", "sql", "--insecure", "--format=csv", "-e"))
       .put("positionColumn", "position")
       .put("operationColumn", "operation")
       .put("pollIntervalMs", 750)
@@ -27,10 +31,15 @@ class CockroachDbReplicationOptionsTest {
     assertEquals("roach.internal", options.getHost());
     assertEquals(26257, options.getPort());
     assertEquals("cdc_orders", options.getSourceTable());
+    assertEquals("2026-02-16T00:00:00Z", options.getInitialCursor());
+    assertEquals("5s", options.getChangefeedOptions().get("resolved"));
+    assertEquals("cockroach", options.getCliCommand().get(0));
     assertEquals(750, options.getPollIntervalMs());
 
     JsonObject json = options.toJson();
     assertEquals("roach.internal", json.getString("host"));
+    assertEquals("2026-02-16T00:00:00Z", json.getString("initialCursor"));
+    assertEquals("cockroach", json.getJsonArray("cliCommand").getString(0));
     assertEquals(2, json.getInteger("maxConcurrentDispatch"));
   }
 
@@ -47,6 +56,6 @@ class CockroachDbReplicationOptionsTest {
     assertTrue(options.isAutoStart());
 
     assertThrows(IllegalArgumentException.class,
-      () -> options.setBatchSize(0).validate());
+      () -> options.setMaxConcurrentDispatch(0).validate());
   }
 }


### PR DESCRIPTION
## Summary
- migrate Cockroach adapter from polling semantics to true CDC using sinkless changefeed
- implement non-prod stream transport via Cockroach SQL CLI process streaming
- add `cliCommand` option for command override (used by container tests via `docker exec`)
- parse sinkless CSV rows + hex payloads into `CockroachDbChangeEvent` (insert/update/delete)
- document customer-facing tradeoffs in README/docs (non-production, dev/test/prototype)

## Tradeoffs (documented in README)
- this is true CDC (not polling)
- this path is intended for dev/test/prototype usage, not production
- runtime environment must have Cockroach SQL CLI access/permissions for stream execution
- production-grade Cockroach CDC should use managed sink integrations

## Validation
- `mvn -pl replication-cockroachdb -am test`

Closes #26
